### PR TITLE
Add parameterized delay to the server refresh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,5 +64,9 @@ interface IOptions {
      * handle this without any additional configuration required.
      */
     push: boolean;
+    /**
+     * Time to wait before sending refresh to browser (in ms)
+     */
+    delay: number;
 }
 ```

--- a/server/flags.ts
+++ b/server/flags.ts
@@ -3,6 +3,7 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
     {name: 'files', alias: 'f', type: String, description: 'The file or directory to watch', multiple: true, defaultOption: true},
     {name: 'push', type: Boolean, description: 'Push file content to websocket', defaultValue: false},
     {name: 'port', type: Number, description: 'The port to host the websocket on', defaultValue: 8796},
+    {name: 'delay', type: Number, description: 'Time to wait before sending refresh signal to browser (in ms)', defaultValue: 0},
 ];
 
 const result = commandLineArgs(optionDefinitions);
@@ -22,6 +23,10 @@ export interface IOptions {
      * handle this without any additional configuration required.
      */
     push: boolean;
+    /**
+     * Time to wait before sending refresh to browser (in ms)
+     */
+    delay: number;
 }
 
 export function getFlags(): IOptions {

--- a/server/server.ts
+++ b/server/server.ts
@@ -7,6 +7,7 @@ import {readFile} from "fs";
 import {IOptions} from "./flags";
 import 'rxjs/add/operator/filter'
 import 'rxjs/add/operator/map'
+import 'rxjs/add/operator/delay'
 import 'rxjs/add/operator/switchMap'
 
 function setupWatchers(options: IOptions): Observable<string> {
@@ -68,6 +69,7 @@ export function startServer(options: IOptions) {
                 return of({name});
             }
         })
+        .delay(options.delay)
         .subscribe((result) => {
             broadcast(server, JSON.stringify(result));
         });


### PR DESCRIPTION
I've integrated it into my Blazor Server's dev pipeline, but I've been having problems when the CSS is in a separate class library. They are loaded via the main project and it's not instant. So the solution is to have a small delay between the file watching and the server refresh. I've added a 'delay' parameter for this.